### PR TITLE
Add ability to customise default request headers

### DIFF
--- a/src/main/java/org/jarling/v2/ApiService.java
+++ b/src/main/java/org/jarling/v2/ApiService.java
@@ -9,6 +9,7 @@ import org.jarling.v2.http.CertificateType;
 import org.jarling.v2.http.SignedHttpsClient;
 
 import java.security.PrivateKey;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -17,14 +18,28 @@ public final class ApiService {
     private final BearerHttpsClient authenticatedRequest;
     private SignedHttpsClient signedRequest;
     private final String starlingBankEndpoint;
+    private final Map<String, String> defaultHeaders;
 
     public ApiService(StarlingBankEnvironment starlingBankEnvironment, String accessToken) {
+        this(starlingBankEnvironment, accessToken, null);
+    }
+
+    public ApiService(StarlingBankEnvironment starlingBankEnvironment, String accessToken, Map<String, String> defaultHeaders) {
+        this.defaultHeaders = new HashMap<>();
+        if (defaultHeaders == null) {
+            this.defaultHeaders.put("User-Agent", "Jarling/0.1 (Starling Bank Java Client Library)");
+        } else {
+            this.defaultHeaders.putAll(defaultHeaders);
+        }
+
         this.starlingBankEndpoint = starlingBankEnvironment.getPath() + API_BASE_PATH;
         this.authenticatedRequest = new BearerHttpsClient(accessToken);
+        this.authenticatedRequest.setDefaultHeaders(this.defaultHeaders);
     }
 
     public void configureRequestSigning(PrivateKey privateKey, UUID publicKeyUid, CertificateType certificateType) {
         this.signedRequest = new SignedHttpsClient(authenticatedRequest.getAccessToken(), privateKey, publicKeyUid, certificateType);
+        this.signedRequest.setDefaultHeaders(this.defaultHeaders);
     }
 
     public boolean canSignRequests() {

--- a/src/main/java/org/jarling/v2/Starling.java
+++ b/src/main/java/org/jarling/v2/Starling.java
@@ -41,10 +41,14 @@ public final class Starling extends StarlingBase implements StarlingBank {
     private static ApiService apiService;
 
     public Starling(StarlingBankEnvironment environment, String accessToken) {
+        this(environment, accessToken, null);
+    }
+
+    public Starling(StarlingBankEnvironment environment, String accessToken, Map<String, String> defaultHeaders) {
         if (accessToken == null || accessToken.equals("")) {
             throw new IllegalArgumentException("access token cannot be null or blank");
         } else {
-            apiService = new ApiService(environment, accessToken);
+            apiService = new ApiService(environment, accessToken, defaultHeaders);
         }
     }
 

--- a/src/main/java/org/jarling/v2/http/BasicHttpsClient.java
+++ b/src/main/java/org/jarling/v2/http/BasicHttpsClient.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BasicHttpsClient {
+
+    private Map<String, String> defaultHeaders;
+
     private HttpResponse request(HttpRequest httpRequest) throws StarlingBankRequestException {
         try {
             HttpsURLConnection httpsURLConnection = (HttpsURLConnection) httpRequest.getFullUrl().openConnection();
@@ -29,9 +32,17 @@ public class BasicHttpsClient {
         return null;
     }
 
+    public void setDefaultHeaders(Map<String, String> defaultHeaders) {
+        this.defaultHeaders = defaultHeaders;
+    }
+
     private Map<String, String> getHeaders(HttpRequest request) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("User-Agent", "Jarling/0.1 (Starling Bank Java Client Library)");
+
+        if (defaultHeaders != null) {
+            headers.putAll(defaultHeaders);
+        }
+
         headers.put("Accept", "application/json");
         if (request.getBody() != null) {
             headers.put("Content-Type", "application/json; charset=utf-8");


### PR DESCRIPTION
Add ability to customise default request headers - useful if want to supply a different User Agent or other headers.